### PR TITLE
Added TAB completion function

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A [Spigot](https://www.spigotmc.org/ "") plugin which allows the players to set 
 - **/wtp \<waypoint name\>** teleports to a waypoint (permission required: **simplewaypoints.waypoints**).
 - **/wlist** shows the of list all waypoints (permission required: **simplewaypoints.waypoints**).
 - **/wdelete \<waypoint name\>** delete a waypoint.
+- **/whome** teleports player to his bed.
 
 ## Permissions:
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>tavonatti.stefano.spigot_plugin.waypoints</groupId>
     <artifactId>SimpleWaypoints</artifactId>
-    <version>0.3</version>
+    <version>0.3-tabbed</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -28,6 +28,4 @@
             <scope>compile</scope>
         </dependency>
     </dependencies>
-
-
 </project>

--- a/src/main/java/tavonatti/stefano/spigot_plugin/waypoints/Main.java
+++ b/src/main/java/tavonatti/stefano/spigot_plugin/waypoints/Main.java
@@ -15,6 +15,7 @@ public class Main extends JavaPlugin{
 
         this.getCommand("wsave").setExecutor(new CommandWSave());
         this.getCommand("wtp").setExecutor(new CommandWTP());
+        this.getCommand("wtp").setTabCompleter(new CommandCompleter()); //registering tab completer
         this.getCommand("wlist").setExecutor(new CommandWList());
         this.getCommand("wdelete").setExecutor(new CommandWDelete());
         this.getCommand("whome").setExecutor(new CommandWHome());

--- a/src/main/java/tavonatti/stefano/spigot_plugin/waypoints/Main.java
+++ b/src/main/java/tavonatti/stefano/spigot_plugin/waypoints/Main.java
@@ -14,12 +14,16 @@ public class Main extends JavaPlugin{
         createWaypointsDir();
 
         this.getCommand("wsave").setExecutor(new CommandWSave());
-        this.getCommand("wtp").setExecutor(new CommandWTP());
-        this.getCommand("wtp").setTabCompleter(new CommandCompleter()); //registering tab completer
-        this.getCommand("wlist").setExecutor(new CommandWList());
-        this.getCommand("wdelete").setExecutor(new CommandWDelete());
-        this.getCommand("whome").setExecutor(new CommandWHome());
 
+        this.getCommand("wtp").setExecutor(new CommandWTP());
+        this.getCommand("wtp").setTabCompleter(new CommandCompleter()); //registering tab completer for /wtp
+
+        this.getCommand("wlist").setExecutor(new CommandWList());
+
+        this.getCommand("wdelete").setExecutor(new CommandWDelete());
+        this.getCommand("wdelete").setTabCompleter(new CommandCompleter()); //registering tab completer for /wdelete
+
+        this.getCommand("whome").setExecutor(new CommandWHome());
     }
 
     private void createWaypointsDir() {

--- a/src/main/java/tavonatti/stefano/spigot_plugin/waypoints/commands/CommandCompleter.java
+++ b/src/main/java/tavonatti/stefano/spigot_plugin/waypoints/commands/CommandCompleter.java
@@ -1,0 +1,41 @@
+package tavonatti.stefano.spigot_plugin.waypoints.commands;
+
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
+import org.bukkit.command.TabCompleter;
+import org.bukkit.entity.Player;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Properties;
+
+public class CommandCompleter implements TabCompleter
+{
+    public List<String> onTabComplete(CommandSender commandSender, Command command, String s, String[] strings)
+    {
+        if(commandSender instanceof Player)
+        {
+            Player player = (Player) commandSender;
+
+            //load file
+            File waypointFile = new File("waypoints/" + player.getName() + "-" +
+                    player.getWorld().getName() + ".properties");
+
+            Properties properties = new Properties();
+            if (CommandWSave.loadWaypointFile(waypointFile, properties)) return null;
+            Iterator it=properties.keySet().iterator();
+
+            //fill ArrayList with names
+            List<String> waypointList = new ArrayList<String>();
+            while (it.hasNext()){
+                waypointList.add(it.next().toString());
+            }
+
+            return waypointList;
+        }
+
+        return null;
+    }
+}

--- a/src/main/java/tavonatti/stefano/spigot_plugin/waypoints/commands/CommandCompleter.java
+++ b/src/main/java/tavonatti/stefano/spigot_plugin/waypoints/commands/CommandCompleter.java
@@ -15,14 +15,11 @@ public class CommandCompleter implements TabCompleter
 {
     public List<String> onTabComplete(CommandSender commandSender, Command command, String s, String[] strings)
     {
-        if(commandSender instanceof Player)
-        {
-            Player player = (Player) commandSender;
+        if(commandSender instanceof Player){
+            Player p = (Player) commandSender;
 
             //load file
-            File waypointFile = new File("waypoints/" + player.getName() + "-" +
-                    player.getWorld().getName() + ".properties");
-
+            File waypointFile = new File("waypoints/" + p.getName() + "-" + p.getWorld().getName() + ".properties");
             Properties properties = new Properties();
             if (CommandWSave.loadWaypointFile(waypointFile, properties)) return null;
             Iterator it=properties.keySet().iterator();

--- a/src/main/java/tavonatti/stefano/spigot_plugin/waypoints/commands/CommandWTP.java
+++ b/src/main/java/tavonatti/stefano/spigot_plugin/waypoints/commands/CommandWTP.java
@@ -63,4 +63,6 @@ public class CommandWTP implements CommandExecutor {
 
         return true;
     }
+
+
 }

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,6 +1,7 @@
 name: SimpleWaypoints
 version: 0.3
-author: Stefano Tavonatti
+api-version: 1.14
+author: Stefano Tavonatti; DKolibar
 main: tavonatti.stefano.spigot_plugin.waypoints.Main
 commands:
   wsave:

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,5 +1,5 @@
 name: SimpleWaypoints
-version: 0.3
+version: 0.3-tabbed
 api-version: 1.14
 author: Stefano Tavonatti; DKolibar
 main: tavonatti.stefano.spigot_plugin.waypoints.Main


### PR DESCRIPTION
I implemented function that player will get TAB completion list for `/wtp` and `/wdelete` commands via [TabCompleter ](https://hub.spigotmc.org/javadocs/spigot/org/bukkit/command/TabCompleter.html) interface

Known bugs: none
Performance hit: probably none :smile:

+I added api-version var to plugin yaml file to mute _"[23:35:24 WARN]: Plugin xyz does not specify an api-version.[39;0m"_ warning